### PR TITLE
Corrigindo capitalização dos nomes de arquivos

### DIFF
--- a/JS/jogo.js
+++ b/JS/jogo.js
@@ -3,6 +3,6 @@ function jogar1() {
 }
 
 function jogar2() {
-    window.location.href="./AventuraNaEta.html"
+    window.location.href="./AventuraNaETA.html"
 }
 

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
                 <label>___</label><a href="jogos.html">Jogos</a>
             </div>
             <div class="agua4">
-                <label>___</label><a href="Dicas.html">Dicas</a>
+                <label>___</label><a href="dicas.html">Dicas</a>
             </div>
         </div>
         


### PR DESCRIPTION
No arquivo "index.html" e no arquivo "jogo.js" os nomes das páginas "dicas.html" e "AventuraNaETA.html" estavam com capitalização incorreta, impedindo o acesso à página de dicas e ao segundo jogo.